### PR TITLE
make provider getter minification safe

### DIFF
--- a/angular-simple-feature-flags.js
+++ b/angular-simple-feature-flags.js
@@ -13,7 +13,7 @@
     };
 
 
-    this.$get = function($rootScope, $q) {
+    this.$get = ['$rootScope', '$q', function($rootScope, $q) {
 
       var flags = this.flags;
       /**
@@ -194,7 +194,7 @@
         guardRoute : guardRoute
       }
 
-    };
+    }];
 
 
   })


### PR DESCRIPTION
When minified, I was getting this error from munged injection:
```
Error: [$injector:unpr] Unknown provider: aProvider <- a <- FeatureFlags <- featureFlagDirective <- FeatureFlags
http://errors.angularjs.org/1.3.16/$injector/unpr?p0=aProvider%20%3C-%20a%20%3C-%20FeatureFlags%20%3C-%20featureFlagDirective%20%3C-%20FeatureFlags
```

Fixed by using the minification safe syntax.